### PR TITLE
Docs revisions

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -17,7 +17,9 @@ The Prodvana provider must be configured with credentials to manage the resource
 ```typescript
 import * as prodvana from "@prodvana/pulumi-prodvana";
 
-const app = new prodvana.Application("my-app");
+const app = new prodvana.Application("my-app", {
+    name: "my-app",
+});
 ```
 
 {{% /choosable %}}
@@ -26,7 +28,7 @@ const app = new prodvana.Application("my-app");
 ```python
 import pulumi_prodvana as prodvana
 
-app = prodvana.Application("my-app")
+app = prodvana.Application("my-app", name="my-app")
 ```
 
 {{% /choosable %}}
@@ -43,7 +45,9 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
-		_, err := prodvana.NewApplication(ctx, "my-app", &prodvana.ApplicationArgs{})
+		_, err := prodvana.NewApplication(ctx, "my-app", &prodvana.ApplicationArgs{
+			Name: pulumi.String("my-app"),
+		})
 		if err != nil {
 			return err
 		}

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,41 +1,41 @@
 ---
 title: Prodvana
 meta_desc: Provides an overview of the Prodvana Provider for Pulumi.
-layout: overview
+layout: package
 ---
 
-The Prodvana provider for Pulumi can be used to provision resources within your Prodvana organization. For example you can create and manage Runtimes, Applications, and Release Channels.
+The [Prodvana](http://prodvana.io/) provider for Pulumi can be used to provision resources within your Prodvana organization. For example you can create and manage Runtimes, Applications, and Release Channels.
+
 The Prodvana provider must be configured with credentials to manage the resources in your Prodvana organization.
 
 ## Example
 
-{{< chooser language "typescript,python,go" >}}
+{{< chooser language "typescript,python,go" />}}
+
 {{% choosable language typescript %}}
 
 ```typescript
-import * as pulumi from "@pulumi/pulumi";
 import * as prodvana from "@prodvana/pulumi-prodvana";
 
-const app = new prodvana.Application("my-app", {
-    name: "my-app",
-});
+const app = new prodvana.Application("my-app");
 ```
- 
+
 {{% /choosable %}}
 {{% choosable language python %}}
 
 ```python
 import pulumi_prodvana as prodvana
 
-app = prodvana.Application("my-app", name="my-app")
+app = prodvana.Application("my-app")
 ```
 
 {{% /choosable %}}
 {{% choosable language go %}}
 
 ```go
+package main
+
 import (
-	"fmt"
 	"github.com/prodvana/pulumi-prodvana/sdk/go/prodvana"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -43,11 +43,9 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
-		_, err := prodvana.NewApplication(ctx, "my-app", &prodvana.ApplicationArgs{
-            Name: pulumi.String("my-app")
-		})
+		_, err := prodvana.NewApplication(ctx, "my-app", &prodvana.ApplicationArgs{})
 		if err != nil {
-			return fmt.Errorf("error creating application: %v", err)
+			return err
 		}
 
 		return nil
@@ -56,5 +54,3 @@ func main() {
 ```
 
 {{% /choosable %}}
-
-{{< /chooser >}}

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Prodvana Installation & Configuration
-meta_desc: Information on how to install the Prodvana provider.
-layout: installation
+meta_desc: Provides an overview of how to install and configure the Prodvana provider.
+layout: package
 ---
 
 ## Installation
@@ -12,6 +12,16 @@ The Prodvana provider is available as a package in the following Pulumi language
 * Python: [`pulumi_prodvana`](https://pypi.org/project/pulumi-prodvana/)
 * Go: [`github.com/prodvana/pulumi-prodvana/sdk/go/prodvana`](https://pkg.go.dev/github.com/prodvana/pulumi-prodvana/sdk)
 
+### Provider Binary
+
+The provider binary is a third party binary. It can be installed using the `pulumi plugin` command.
+
+```bash
+pulumi plugin install resource prodvana <version> --server github://api.github.com/prodvana
+```
+
+Replace the version string with your desired version.
+
 ## Setup
 
 To provision resources with the Pulumi Prodvana provider, you need to pass in your Prodvana organization's `orgSlug` and a valid `apiToken`. See [these instructions](https://docs.prodvana.io/docs/api-tokens-1) for creating an API Token.
@@ -20,7 +30,7 @@ To provision resources with the Pulumi Prodvana provider, you need to pass in yo
 
 Use `pulumi config set prodvana:<option> (--secret)`.
 
-| Option | Environment Variable | Required/Optional | Description | 
+| Option | Environment Variable | Required/Optional | Description |
 |-----|------|------|----|
-| `org_slug`| `PVN_ORG_SLUG` | Required | Prodvana Org Slug, found in your Prodvana url `<org_slug>.prodvana.io` |
-| `api_token`| `PVN_API_TOKEN` | Required (Secret) | API Token with permissions to the Prodvana Organization |
+| `orgSlug`| `PVN_ORG_SLUG` | Required | Prodvana Org Slug, found in your Prodvana url `<org_slug>.prodvana.io` |
+| `apiToken`| `PVN_API_TOKEN` | Required (Secret) | API Token with permissions to the Prodvana Organization |


### PR DESCRIPTION
Adds a few revisions to the overview and install/configure docs:

* Uses the `package` layout (we updated this recently)
* Adds a link to prodvana.io
* Adjusts meta descriptions and code samples for consistency
* Adds a copyable snippet for installing the provider binary
* Fixes the names of required config parameters
* Removes the optional `name` parameter from resource declarations

Hopefully this last one is all right -- I don't have a Prodvana account, so unfortunately I'm not to test. But by convention, the `name` argument is usually omitted, as it overrides the physical name that Pulumi sets implicitly (via [auto-naming](https://www.pulumi.com/docs/concepts/resources/names/#autonaming)). This is generally considered a best practice, but if for some reason it doesn't work for Prodvana, let me know and I'd be happy add these back in.

Thanks again!